### PR TITLE
Fix heater faults in the presence of extrusion temperature boost

### DIFF
--- a/src/Heating/LocalHeater.cpp
+++ b/src/Heating/LocalHeater.cpp
@@ -196,6 +196,12 @@ GCodeResult LocalHeater::SwitchOn(const StringRef& reply) noexcept
 		return GCodeResult::error;
 	}
 
+	DoSwitchOn();
+	return GCodeResult::ok;
+}
+
+void LocalHeater::DoSwitchOn() noexcept
+{
 	const float target = min<float>(GetTargetTemperature() + extrusionTemperatureBoost, GetHighestTemperatureLimit());
 	const HeaterMode newMode = (temperature + TemperatureCloseEnough < target) ? HeaterMode::heating
 					: (temperature > target + TemperatureCloseEnough) ? HeaterMode::cooling
@@ -212,7 +218,6 @@ GCodeResult LocalHeater::SwitchOn(const StringRef& reply) noexcept
 		heatingFaultCount = 0;
 		mode = newMode;
 	}
-	return GCodeResult::ok;
 }
 
 // Switch off the specified heater. If in tuning mode, delete the array used to store tuning temperature readings.
@@ -286,10 +291,8 @@ void LocalHeater::Spin() noexcept
 
 			if (IsPidMode(mode) && extrusionTemperatureBoost != lastExtrusionTemperatureBoost)
 			{
-				// Calculate new heater mode to prevent heater fault due to exceededAllowedExcursion
-				mode = (temperature + TemperatureCloseEnough < targetTemperature) ? HeaterMode::heating
-						: (temperature > targetTemperature + TemperatureCloseEnough) ? HeaterMode::cooling
-							: HeaterMode::stable;
+				// Calculate new heater mode to prevent heater fault due to exceededAllowedExcursion or temperatureRisingTooSlowly
+				DoSwitchOn();
 				lastExtrusionTemperatureBoost = extrusionTemperatureBoost;
 			}
 
@@ -416,9 +419,13 @@ void LocalHeater::Spin() noexcept
 					}
 					else
 					{
-						iAccumulator = constrain<float>
-										(iAccumulator + (error * params.kP * params.recipTi * HeatSampleIntervalMillis * MillisToSeconds),
-											0.0, GetModel().GetMaxPwm());
+						const float errorToUse = error;
+						{
+							InterruptCriticalSectionLocker lock;          // avoid a race with tasks that implement feedforward
+							iAccumulator = constrain<float>
+											(iAccumulator + (errorToUse * params.kP * params.recipTi * HeatSampleIntervalMillis * MillisToSeconds),
+												0.0, GetModel().GetMaxPwm());
+						}
 						lastPwm = constrain<float>(pPlusD + iAccumulator, 0.0, GetModel().GetMaxPwm());
 					}
 

--- a/src/Heating/LocalHeater.h
+++ b/src/Heating/LocalHeater.h
@@ -50,6 +50,7 @@ protected:
 	GCodeResult UpdateModel(const StringRef& reply) noexcept override;	// Called when the heater model has been changed
 
 private:
+	void DoSwitchOn() noexcept;
 	void SetHeater(float power) const noexcept;					// Power is a fraction in [0,1]
 	TemperatureError ReadTemperature() noexcept;				// Read and store the temperature of this heater
 	void DoTuningStep() noexcept;								// Called on each temperature sample when auto tuning


### PR DESCRIPTION
The old logic was calculating temperature rise across an arbitrary sequence of temperature boost and de-boosts, potentially from different starting temperatures, which doesn't make sense physically. This resulted in temperatureRisingTooSlowly faults at random. Some of these faults would even report a negative temperature rise (with fully functioning hardware and good tunings) due to calculating the rise from different starting temperatures.

The new logic will still trigger faults for complete hardware failures, because the mode will stay in HeaterMode::heating as the sensor reading continues to fall which means the values for calculating the heating rate will not be reset.

Also add a missing InterruptCriticalSectionLocker, which is already present in the RepRapFirmware version of this file.

Tested on a printer with a high flow hotend with a temperature sensor that's slow to respond, see https://forum.duet3d.com/topic/37489/3-6-0-beta-4-heater-feed-forward-leads-to-heater-faults for details.