### PR TITLE
CAN: use bounded timeout in CanClockLoop to prevent startup deadlock

### DIFF
--- a/src/CAN/CanInterface.cpp
+++ b/src/CAN/CanInterface.cpp
@@ -753,13 +753,21 @@ extern "C" [[noreturn]] void CanClockLoop(void *) noexcept
 	for (;;)
 	{
 		CanMessageBuffer buf;
-		can0dev->ReceiveMessage(
+		bool status = can0dev->ReceiveMessage(
 #if RP2040
 								CanDevice::RxBufferNumber::fifo1,
 #else
 								CanDevice::RxBufferNumber::buffer0,
 #endif
-									TaskBase::TimeoutUnlimited, &buf);
+									500, &buf);  // we expect a new sync message every 211ms
+		if (status == false)
+		{
+			if (Platform::Debug(Module::CAN))
+			{
+				debugPrintf("Timeout while waiting for CAN time sync message\n");
+			}
+			continue;
+		}
 		if (buf.id.MsgType() == CanMessageType::timeSync
 #if defined(ATEIO) || defined(ATECM)
 			&& (buf.id.Src() == CanId::ATEMasterAddress))			// ATE boards only respond to the ATE master, because a main board under test may also transmit when it starts up


### PR DESCRIPTION
CanClockLoop could deadlock at boot when ReceiveMessage() used TimeoutUnlimited, especially during heavy CAN error-frame storms. NDAT can already indicate data present, but the waiting task is not reliably woken via task notifications, so it never re-checks NDAT and blocks forever. A finite timeout breaks this by forcing a periodic NDAT poll; once recovered, the issue does not reappear during normal operation.

Use a 500ms timeout (sync period ~211ms) instead of relying on ISR-side fixes, keeping the ISR simple and avoiding additional interrupt load under storms. Update the debug output accordingly.

See https://forum.duet3d.com/topic/38862/3-6-2beta1-sbc-tool1lc-no-sync-no-movement