### PR TITLE
[feature] port spin-lockup + watchdog diagnostics from RepRapFirmware and added out-of-sync detection

### DIFF
--- a/src/Hardware/ExceptionHandlers.cpp
+++ b/src/Hardware/ExceptionHandlers.cpp
@@ -20,6 +20,7 @@ void SoftwareReset(SoftwareResetReason initialReason, const uint32_t *_ecv_array
 
 	Cache::Disable();
 
+	fullReason |= Tasks::GetSpinningModule().ToBaseType();
 	if (Platform::WasDeliberateError())
 	{
 		fullReason |= (uint16_t)SoftwareResetReason::deliberate;

--- a/src/Hardware/SoftwareReset.cpp
+++ b/src/Hardware/SoftwareReset.cpp
@@ -164,7 +164,10 @@ void SoftwareResetData::PrintPart1(unsigned int slot, const StringRef& reply) co
 # endif
 #endif
 
-	reply.catf(", available RAM %" PRIi32 ", slot %u", neverUsedRam, slot);
+	reply.catf(", %s spinning, available RAM %" PRIi32 ", slot %u",
+			Module(resetReason & 0x1F).ToString(),
+			neverUsedRam,
+			slot);
 
 	// Our format buffer is only 256 characters long, so the next 2 lines must be written separately
 	// The task name may include nulls at the end, so print it as a string

--- a/src/Platform/Platform.cpp
+++ b/src/Platform/Platform.cpp
@@ -86,7 +86,8 @@ enum class DeferredCommand : uint8_t
 	testDivideByZero,
 	testUnalignedMemoryAccess,
 	testBadMemoryAccess,
-	testMemoryLeak
+	testMemoryLeak,
+	testSpinLockup
 };
 
 static volatile DeferredCommand deferredCommand = DeferredCommand::none;
@@ -130,7 +131,8 @@ namespace Platform
 
 	static uint32_t lastPollTime;
 	static uint32_t lastFanCheckTime = 0;
-	static unsigned int heatTaskIdleTicks = 0;
+	static uint32_t heatTaskIdleTicks = 0;
+	static uint32_t syncedIdleTicks = 0;
 
 	static uint32_t whenLastCanMessageProcessed = 0;
 
@@ -802,6 +804,11 @@ void Platform::Spin()
 			deliberateError = false;
 			break;
 
+		case DeferredCommand::testSpinLockup:
+			deliberateError = true;
+			while (true) { }
+			break;
+
 		default:
 			break;
 		}
@@ -867,8 +874,12 @@ void Platform::Spin()
 	}
 
 	// Update the Status LED. Flash it quickly (8Hz) if we are not synced to the master, else flash in sync with the master (about 2Hz).
+	const bool synced = StepTimer::CheckSynced();
+	if (synced) {
+		syncedIdleTicks = 0;
+	}
 	WriteLed(0,
-				(StepTimer::CheckSynced())
+				(synced)
 					? (StepTimer::GetMasterTime() & (1u << 19)) != 0
 						: (StepTimer::GetTimerTicks() & (1u << 17)) != 0
 		    );
@@ -1127,6 +1138,11 @@ uint32_t Platform::GetHeatTaskIdleTicks()
 	return heatTaskIdleTicks;
 }
 
+uint32_t Platform::GetSyncedIdleTicks()
+{
+	return syncedIdleTicks;
+}
+
 #if USE_SERIAL_DEBUG
 
 // Output a character to the debug channel
@@ -1253,6 +1269,7 @@ const UniqueIdBase& Platform::GetUniqueId() noexcept
 void Platform::Tick() noexcept
 {
 	++heatTaskIdleTicks;
+	++syncedIdleTicks;
 }
 
 void Platform::StartFirmwareUpdate()
@@ -1384,6 +1401,10 @@ GCodeResult Platform::DoDiagnosticTest(const CanMessageDiagnosticTest& msg, cons
 
 	case 1001:	// test watchdog
 		deferredCommand = DeferredCommand::testWatchdog;
+		return GCodeResult::ok;
+
+	case 1002: // test that we get a software reset if a Spin() function takes too long
+		deferredCommand = DeferredCommand::testSpinLockup;
 		return GCodeResult::ok;
 
 	case 1004:

--- a/src/Platform/Platform.h
+++ b/src/Platform/Platform.h
@@ -148,6 +148,7 @@ namespace Platform
 
 	void KickHeatTaskWatchdog() noexcept;
 	uint32_t GetHeatTaskIdleTicks() noexcept;
+	uint32_t GetSyncedIdleTicks() noexcept;
 
 #if HAS_ADDRESS_SWITCHES
 	uint8_t ReadBoardAddress() noexcept;

--- a/src/Platform/Tasks.cpp
+++ b/src/Platform/Tasks.cpp
@@ -85,9 +85,9 @@ constexpr uint8_t memPattern = 0xA5;
 constexpr unsigned int MainTaskStackWords = 830;				// this seems very large; but a user had a stack overflow when it was set to 800
 constexpr unsigned int UpdateBootloaderTaskStackWords = 300;
 
-static bool checkSpinLock = false;
+static volatile bool spinLockChecksEnabled = false;
 static volatile uint32_t ticksInSpinState = 0;
-Module volatile spinningModule = Module::numModules;
+static volatile Module spinningModule = Module::numModules;
 
 static TaskBase *mainTask = nullptr;
 static Mutex mallocMutex;
@@ -309,6 +309,22 @@ static bool watchdogCausedReboot = false;
 	while (true) { }
 }
 
+static inline void SetSpinLockChecksEnabled(bool enabled) noexcept
+{
+	spinLockChecksEnabled = enabled;
+	if (!enabled)
+	{
+		ticksInSpinState = 0;
+		spinningModule = Module::numModules;
+	}
+}
+
+static inline void EnterSpin(Module module) noexcept
+{
+	ticksInSpinState = 0;
+	spinningModule = module;
+}
+
 // The main task loop that runs during normal operation
 extern "C" [[noreturn]] void MainTask(void *pvParameters) noexcept
 {
@@ -321,20 +337,17 @@ extern "C" [[noreturn]] void MainTask(void *pvParameters) noexcept
 	moveInstance->Init();
 #endif
 
-	checkSpinLock = true;
+	SetSpinLockChecksEnabled(true);
 	for (;;)
 	{
-		ticksInSpinState = 0;
-		spinningModule = Module::Platform;
+		EnterSpin(Module::Platform);
 		Platform::Spin();
 
-		ticksInSpinState = 0;
-		spinningModule = Module::CAN;
+		EnterSpin(Module::CAN);
 		CommandProcessor::Spin();
 
 #if SUPPORT_DRIVERS
-		ticksInSpinState = 0;
-		spinningModule = Module::FilamentSensors;
+		EnterSpin(Module::FilamentSensors);
 		FilamentMonitor::Spin();
 #endif
 	}
@@ -1009,17 +1022,20 @@ void *Tasks::AllocPermanent(size_t sz, std::align_val_t align) noexcept
 	return ret;
 }
 
-extern "C" void vApplicationTickHook(void) noexcept
+static inline void CheckSpinLockAndResetIfStuck() noexcept
 {
-	CoreSysTick();
-	WatchdogReset();							// kick the watchdog
-	Platform::Tick();
+	if (!spinLockChecksEnabled)
+	{
+		return;
+	}
+
 	++ticksInSpinState;
 
 	// only check stuck state when main task is running - disabled for bootloader task
-	const bool mainTaskStuck = (checkSpinLock && ticksInSpinState >= Tasks::MaxMainTaskTicksInSpinState);
-	const bool heatTaskStuck = (checkSpinLock && Platform::GetHeatTaskIdleTicks() >= Tasks::MaxHeatTaskTicksInSpinState);
-	const bool syncedStuck = (checkSpinLock && Platform::GetSyncedIdleTicks() >= Tasks::MaxMainTaskTicksInSpinState);
+	const bool mainTaskStuck = (ticksInSpinState >= Tasks::MaxMainTaskTicksInSpinState);
+	const bool heatTaskStuck = (Platform::GetHeatTaskIdleTicks() >= Tasks::MaxHeatTaskTicksInSpinState);
+	const bool syncedStuck = (Platform::GetSyncedIdleTicks() >= Tasks::MaxMainTaskTicksInSpinState);
+
 	if (heatTaskStuck || syncedStuck || mainTaskStuck)		// if we stall, save diagnostic data and reset
 	{
 		Heat::SwitchOffAll();
@@ -1034,12 +1050,21 @@ extern "C" void vApplicationTickHook(void) noexcept
 #endif
 
 		// We now save the stack when we get stuck in a spin loop
-		__asm volatile("mrs r2, psp");
-		register const uint32_t * stackPtr asm ("r2");					// we want the PSP not the MSP
+		const uint32_t * stackPtr;
+		__asm volatile("mrs %0, psp" : "=r"(stackPtr)); // we want the PSP not the MSP
 		SoftwareReset(
-				(heatTaskStuck) ? SoftwareResetReason::heaterWatchdog :SoftwareResetReason::stuckInSpin,
+				(heatTaskStuck) ? SoftwareResetReason::heaterWatchdog : SoftwareResetReason::stuckInSpin,
 			stackPtr + 5);												// discard uninteresting registers, keep LR PC PSR
 	}
+}
+
+extern "C" void vApplicationTickHook(void) noexcept
+{
+	CoreSysTick();
+	WatchdogReset();							// kick the watchdog
+	Platform::Tick();
+
+	CheckSpinLockAndResetIfStuck();
 }
 
 static StaticTask_t xTimerTaskTCB;

--- a/src/Platform/Tasks.cpp
+++ b/src/Platform/Tasks.cpp
@@ -15,6 +15,8 @@
 #include <FilamentMonitors/FilamentMonitor.h>
 #include <Hardware/Devices.h>
 #include <Hardware/NonVolatileMemory.h>
+#include <Hardware/SoftwareReset.h>
+#include <Hardware/ExceptionHandlers.h>
 #include <CanMessageBuffer.h>
 #include <CanMessageFormats.h>
 #include <Duet3Common.h>
@@ -83,9 +85,12 @@ constexpr uint8_t memPattern = 0xA5;
 constexpr unsigned int MainTaskStackWords = 830;				// this seems very large; but a user had a stack overflow when it was set to 800
 constexpr unsigned int UpdateBootloaderTaskStackWords = 300;
 
+static bool checkSpinLock = false;
+static volatile uint32_t ticksInSpinState = 0;
+Module volatile spinningModule = Module::numModules;
+
 static TaskBase *mainTask = nullptr;
 static Mutex mallocMutex;
-static unsigned int heatTaskIdleTicks = 0;
 
 // Idle task data
 constexpr unsigned int IdleTaskStackWords = 50;					// currently we don't use the idle talk for anything, so this can be quite small
@@ -316,11 +321,20 @@ extern "C" [[noreturn]] void MainTask(void *pvParameters) noexcept
 	moveInstance->Init();
 #endif
 
+	checkSpinLock = true;
 	for (;;)
 	{
+		ticksInSpinState = 0;
+		spinningModule = Module::Platform;
 		Platform::Spin();
+
+		ticksInSpinState = 0;
+		spinningModule = Module::CAN;
 		CommandProcessor::Spin();
+
 #if SUPPORT_DRIVERS
+		ticksInSpinState = 0;
+		spinningModule = Module::FilamentSensors;
 		FilamentMonitor::Spin();
 #endif
 	}
@@ -1000,26 +1014,32 @@ extern "C" void vApplicationTickHook(void) noexcept
 	CoreSysTick();
 	WatchdogReset();							// kick the watchdog
 	Platform::Tick();
-	++heatTaskIdleTicks;
-#if 0
-	const bool heatTaskStuck = (heatTaskIdleTicks >= MaxTicksInSpinState);
-	if (heatTaskStuck || ticksInSpinState >= MaxTicksInSpinState)		// if we stall for 20 seconds, save diagnostic data and reset
+	++ticksInSpinState;
+
+	// only check stuck state when main task is running - disabled for bootloader task
+	const bool mainTaskStuck = (checkSpinLock && ticksInSpinState >= Tasks::MaxMainTaskTicksInSpinState);
+	const bool heatTaskStuck = (checkSpinLock && Platform::GetHeatTaskIdleTicks() >= Tasks::MaxHeatTaskTicksInSpinState);
+	const bool syncedStuck = (checkSpinLock && Platform::GetSyncedIdleTicks() >= Tasks::MaxMainTaskTicksInSpinState);
+	if (heatTaskStuck || syncedStuck || mainTaskStuck)		// if we stall, save diagnostic data and reset
 	{
-		resetting = true;
-		for (size_t i = 0; i < MaxHeaters; i++)
-		{
-			Platform::SetHeater(i, 0.0);
-		}
-		Platform::DisableAllDrives();
+		Heat::SwitchOffAll();
+#if SUPPORT_DRIVERS
+# if SUPPORT_TMC51xx
+		IoPort::WriteDigital(GlobalTmc51xxEnablePin, true);
+# endif
+# if SUPPORT_TMC22xx
+		IoPort::WriteDigital(GlobalTmc22xxEnablePin, true);
+# endif
+		moveInstance->DisableAllDrives();
+#endif
 
 		// We now save the stack when we get stuck in a spin loop
 		__asm volatile("mrs r2, psp");
 		register const uint32_t * stackPtr asm ("r2");					// we want the PSP not the MSP
-		Platform::SoftwareReset(
-			(heatTaskStuck) ? (uint16_t)SoftwareResetReason::heaterWatchdog : (uint16_t)SoftwareResetReason::stuckInSpin,
+		SoftwareReset(
+				(heatTaskStuck) ? SoftwareResetReason::heaterWatchdog :SoftwareResetReason::stuckInSpin,
 			stackPtr + 5);												// discard uninteresting registers, keep LR PC PSR
 	}
-#endif
 }
 
 static StaticTask_t xTimerTaskTCB;
@@ -1038,6 +1058,8 @@ extern "C" void vApplicationGetTimerTaskMemory(StaticTask_t **ppxTimerTaskTCBBuf
     /* Pass out the size of the array pointed to by *ppxTimerTaskStackBuffer. */
     *pulTimerTaskStackSize = ARRAY_SIZE(uxTimerTaskStack);
 }
+
+Module Tasks::GetSpinningModule() noexcept { return spinningModule; }
 
 // Helper function to cause a divide by zero error without the compiler noticing we are doing that
 uint32_t Tasks::DoDivide(uint32_t a, uint32_t b) noexcept

--- a/src/Platform/Tasks.h
+++ b/src/Platform/Tasks.h
@@ -35,7 +35,6 @@ namespace Tasks
 
 	static constexpr uint32_t MaxHeatTaskTicksInSpinState = 4000;	// timeout before we reset the processor if the heat task doesn't run
 	static constexpr uint32_t MaxMainTaskTicksInSpinState = 60000;	// timeout before we reset the processor if the main task doesn't run
-	static constexpr uint32_t HighMainTaskTicksInSpinState = 16000;	// how long before we warn that timeout is approaching
 }
 
 // Functions called by CanMessageBuffer in CANlib

--- a/src/Platform/Tasks.h
+++ b/src/Platform/Tasks.h
@@ -30,6 +30,12 @@ namespace Tasks
 	void *DoMemoryLeak() noexcept;
 	uint32_t DoMemoryRead(const uint32_t* addr) noexcept;
 	void *GetNVMBuffer(const uint32_t *_ecv_array null stk) noexcept;
+
+	Module GetSpinningModule() noexcept;
+
+	static constexpr uint32_t MaxHeatTaskTicksInSpinState = 4000;	// timeout before we reset the processor if the heat task doesn't run
+	static constexpr uint32_t MaxMainTaskTicksInSpinState = 60000;	// timeout before we reset the processor if the main task doesn't run - timeout must be long enough to update the bootloader
+	static constexpr uint32_t HighMainTaskTicksInSpinState = 16000;	// how long before we warn that timeout is approaching
 }
 
 // Functions called by CanMessageBuffer in CANlib

--- a/src/Platform/Tasks.h
+++ b/src/Platform/Tasks.h
@@ -34,7 +34,7 @@ namespace Tasks
 	Module GetSpinningModule() noexcept;
 
 	static constexpr uint32_t MaxHeatTaskTicksInSpinState = 4000;	// timeout before we reset the processor if the heat task doesn't run
-	static constexpr uint32_t MaxMainTaskTicksInSpinState = 60000;	// timeout before we reset the processor if the main task doesn't run - timeout must be long enough to update the bootloader
+	static constexpr uint32_t MaxMainTaskTicksInSpinState = 60000;	// timeout before we reset the processor if the main task doesn't run
 	static constexpr uint32_t HighMainTaskTicksInSpinState = 16000;	// how long before we warn that timeout is approaching
 }
 


### PR DESCRIPTION
Bring over the “stuck in spin loop” detection and related watchdog checks from the
main RepRapFirmware codebase into Duet3Expansion to improve robustness and
post-mortem diagnostics.

Under heavy load or fault conditions, the expansion firmware can end up stuck
inside a Spin() loop or stop making forward progress (e.g. main loop stalled,
heat task not being serviced, or prolonged loss of synchronisation with the
master). Previously, these situations could be difficult to detect and diagnose
on the expansion board and could result in the firmware appearing to hang.

This change adds:
- Main-task spin lockup detection using a tick counter (ticksInSpinState)
  maintained from vApplicationTickHook().
- Heat task watchdog monitoring based on Platform::GetHeatTaskIdleTicks().
- A synchronisation progress watchdog based on StepTimer sync state
  (GetSyncedIdleTicks()).
- Safe emergency shutdown on detection (switch off heaters, disable drives),
  followed by a software reset with stack capture to aid debugging.
- Recording the currently spinning module in the reset reason and including it
  in the reset diagnostics output.
- A diagnostic command to deliberately trigger a spin lockup, allowing the
  detection and reset path to be verified.

The main-task spin lock timeout is intentionally set to 60 seconds on the
expansion board (rather than the 20 seconds used in RepRapFirmware). The
expansion firmware has a different role and timing profile, and without the
same level of system-wide knowledge and field experience, a more conservative
threshold reduces the risk of false positives while still guaranteeing recovery
from genuine lockups. This provides a reasonable upper bound that can be
tightened later if appropriate.

The stack capture logic is ported from RepRapFirmware as closely as possible;
however, the expansion project targets different architectures, so this part
may require further review or adjustment by maintainers to ensure correctness
across all supported platforms.

Overall, the goal is feature parity with RepRapFirmware’s safety and diagnostic
behaviour, ensuring the expansion firmware fails safe and reports actionable
information when forward progress stalls.